### PR TITLE
Change type attribute of email input field

### DIFF
--- a/src/pages/auth/signIn.js
+++ b/src/pages/auth/signIn.js
@@ -97,7 +97,7 @@ class Signin extends React.Component {
 
                                             <div className="form_item">
                                                 <div className="form_input">
-                                                    <input type="text" name="email" placeholder="Email" value={email} onChange={this.handleChange.bind(this)} />
+                                                    <input type="email" name="email" placeholder="Email" value={email} onChange={this.handleChange.bind(this)} />
                                                     <span className="bottom_border"></span>
                                                 </div>
                                             </div>


### PR DESCRIPTION
The email field is case sensitive. On mobile `type='text'` will auto capitalise, `type='email'` will not.